### PR TITLE
Enable OpenMP compiler option for MSVC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ MOD_NAMES = [
 # which is really known only after finalize_options
 # http://stackoverflow.com/questions/724664/python-distutils-how-to-get-a-compiler-that-is-going-to-be-used
 compile_options =  {
-    'msvc': ['/Ox', '/EHsc'],
+    'msvc': ['/Ox', '/EHsc', '/openmp'],
     'mingw32' : ['-O3', '-Wno-strict-prototypes', '-Wno-unused-function'],
     'other' : ['-O3', '-Wno-strict-prototypes', '-Wno-unused-function']
 }


### PR DESCRIPTION
Enable OpenMP compiler option for MSVC to support Multi-Threading for nlp.pipe(). Without this option multi-threading done in pipe() method will not work on Windows. MSVC [supports](https://msdn.microsoft.com/en-us/library/fw509c3b.aspx) OpenMP 2.0 which will be enabled by passing this argument to the compiler. 