### PR TITLE
Fix get_lang_class parsing (take 2)

### DIFF
--- a/spacy/util.py
+++ b/spacy/util.py
@@ -23,7 +23,7 @@ def set_lang_class(name, cls):
 
 
 def get_lang_class(name):
-    lang = re.split('[^a-zA-Z0-9_]', name, 1)[0]
+    lang = re.split('[^a-zA-Z0-9]', name, 1)[0]
     if lang not in LANGUAGES:
         raise RuntimeError('Language not supported: %s' % lang)
     return LANGUAGES[lang]


### PR DESCRIPTION
This is the proper fix for get_lang_class parsing. Previous PR: https://github.com/spacy-io/spaCy/pull/384

Value for `lang` given `en>=1.1.0,<1.2.0`: `en`
Value for `lang` given `en_glove_cc_300_1m_vectors`: `en`

Output from `python -m pytest spacy`: `187 passed, 98 skipped, 5 xfailed, 2 xpassed in 253.32 seconds`