### PR TITLE
Exit code 0 for when downloading a model that already was downloaded

### DIFF
--- a/spacy/download.py
+++ b/spacy/download.py
@@ -17,7 +17,7 @@ def download(lang, force=False):
         sputnik.package(about.__title__, about.__version__, about.__models__[lang])
         print("Model already installed. Please run 'python -m "
               "spacy.%s.download --force' to reinstall." % lang, file=sys.stderr)
-        sys.exit(1)
+        sys.exit(0)
     except (PackageNotFoundException, CompatiblePackageNotFoundException):
         pass
 


### PR DESCRIPTION
This very simple PR encompasses the following proposal:

When trying to download data models that already exist locally, the exit code should not be 1 ('error').
This is more inline with other packages which support post-install data download steps, such as NLTK.

This issue came up for me when trying to use spaCy in a production environment: using AWS CodeDeploy with a AfterInstall application lifecycle hook that calls 'python -m spacy.en.download' as part of deployment should succeed the first time, and on subsequent deployments it would be ideal if it would just be a 'no-op' (e.g behave in a more idempotent manner, which is friendlier towards automation generally speaking)

