### PR TITLE
Fix doc

### DIFF
--- a/website/docs/_quickstart-examples.jade
+++ b/website/docs/_quickstart-examples.jade
@@ -46,13 +46,13 @@
         assert token.shape_ == 'Xxxxx'
         for lexeme in nlp.vocab:
             if lexeme.is_alpha:
-                lexeme.shape_ = 'W'
+                lexeme.shape_ = u'W'
             elif lexeme.is_digit:
-                lexeme.shape_ = 'D'
+                lexeme.shape_ = u'D'
             elif lexeme.is_punct:
-                lexeme.shape_ = 'P'
+                lexeme.shape_ = u'P'
             else:
-                lexeme.shape_ = 'M'
+                lexeme.shape_ = u'M'
         assert token.shape_ == 'W'
 
     +h3('examples-numpy-arrays') Export to numpy arrays


### PR DESCRIPTION
This PR changes the `str`s to `unicode`s because `str`s throw the following error:

```
TypeError: Argument 'x' has incorrect type (expected unicode, got str)
```